### PR TITLE
Add null expression treatment

### DIFF
--- a/ExpressionExtensionSQL.Dapper/DapperExtension.cs
+++ b/ExpressionExtensionSQL.Dapper/DapperExtension.cs
@@ -10,7 +10,7 @@ namespace ExpressionExtensionSQL.Dapper {
 
 
         private static KeyValuePair<string, DynamicParameters> GetWhere<TReturn>(Expression<Func<TReturn, bool>> expression, string sql) {
-            var whereSql = expression.ToSql();
+            var whereSql = expression?.ToSql() ?? WherePart.Empty;
             var parameter = new DynamicParameters();
 
             if (whereSql != null) {

--- a/ExpressionExtensionSQL.Dapper/DapperExtension.cs
+++ b/ExpressionExtensionSQL.Dapper/DapperExtension.cs
@@ -13,12 +13,10 @@ namespace ExpressionExtensionSQL.Dapper {
             var whereSql = expression?.ToSql() ?? WherePart.Empty;
             var parameter = new DynamicParameters();
 
-            if (whereSql != null) {
-                foreach (var param in whereSql.Parameters) {
-                    parameter.Add(param.Key, param.Value);
-                }
-                sql = sql.Replace("{where}", " WHERE " + whereSql.Sql);
+            foreach (var param in whereSql.Parameters) {
+                parameter.Add(param.Key, param.Value);
             }
+            sql = sql.Replace("{where}", whereSql.HasSql ? " WHERE " + whereSql.Sql : string.Empty);
 
             return new KeyValuePair<string, DynamicParameters>(sql, parameter);
         }

--- a/ExpressionExtensionSQL.Dapper/DapperExtension.cs
+++ b/ExpressionExtensionSQL.Dapper/DapperExtension.cs
@@ -16,7 +16,7 @@ namespace ExpressionExtensionSQL.Dapper {
             foreach (var param in whereSql.Parameters) {
                 parameter.Add(param.Key, param.Value);
             }
-            sql = sql.Replace("{where}", whereSql.HasSql ? " WHERE " + whereSql.Sql : string.Empty);
+            sql = sql.Replace("{where}", whereSql.HasSql ? $" WHERE {whereSql.Sql}" : string.Empty);
 
             return new KeyValuePair<string, DynamicParameters>(sql, parameter);
         }

--- a/ExpressionExtensionSQL/WherePart.cs
+++ b/ExpressionExtensionSQL/WherePart.cs
@@ -8,6 +8,7 @@ namespace ExpressionExtensionSQL {
     public class WherePart {
 
         public string Sql { get;  set; }
+        public bool HasSql => !string.IsNullOrEmpty(Sql);
 
         public Dictionary<string, object> Parameters { get; private set; } = new Dictionary<string, object>();
 

--- a/ExpressionExtensionSQL/WherePart.cs
+++ b/ExpressionExtensionSQL/WherePart.cs
@@ -56,5 +56,7 @@ namespace ExpressionExtensionSQL {
                 Sql = $"({left.Sql} {@operator} {right.Sql})"
             };
         }
+
+        public static WherePart Empty => new WherePart { Sql = string.Empty };
     }
 }


### PR DESCRIPTION
# What have been done?
If a null expression be passed as paraneter, to get a ***SQL WHERE CLAUSE***, **string.Empty** will be returned.

# Why it have been done?
An exception could be throwed, if the given expression filter parameter are **null**.
