### PR TITLE
Conversion of null and booleans right members

### DIFF
--- a/ExpressionExtensionSQL.Tests/Entities/Merchant.cs
+++ b/ExpressionExtensionSQL.Tests/Entities/Merchant.cs
@@ -7,5 +7,6 @@ namespace ExpressionExtensionSQL.Tests.Entities {
         public string Name { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? DeletedAt { get; set; }
+        public bool IsEnabled { get; set; }
     }
 }

--- a/ExpressionExtensionSQL.Tests/Entities/Merchant.cs
+++ b/ExpressionExtensionSQL.Tests/Entities/Merchant.cs
@@ -6,6 +6,6 @@ namespace ExpressionExtensionSQL.Tests.Entities {
         public int Id { get; set; }
         public string Name { get; set; }
         public DateTime CreatedAt { get; set; }
-
+        public DateTime? DeletedAt { get; set; }
     }
 }

--- a/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
+++ b/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
@@ -108,5 +108,37 @@ namespace ExpressionExtensionSQL.Test
             var where = expression.ToSql();
             where.Sql.Should().Be("([Merchant].[DeletedAt] IS NOT NULL)");
         }
+
+        [Fact(DisplayName = "SingleExpression - boolean - true")]
+        public void BooleanExpressionTrue()
+        {
+            Expression<Func<Merchant, bool>> expression = x => x.IsEnabled == true;
+            var where = expression.ToSql();
+            where.Sql.Should().Be("([Merchant].[IsEnabled] = 1)");
+        }
+
+        [Fact(DisplayName = "SingleExpression - boolean - false")]
+        public void BooleanExpressionFalse()
+        {
+            Expression<Func<Merchant, bool>> expression = x => x.IsEnabled == false;
+            var where = expression.ToSql();
+            where.Sql.Should().Be("([Merchant].[IsEnabled] = 0)");
+        }
+
+        [Fact(DisplayName = "SingleExpression - boolean - true - unary")]
+        public void BooleanExpressionTrueUnary()
+        {
+            Expression<Func<Merchant, bool>> expression = x => x.IsEnabled;
+            var where = expression.ToSql();
+            where.Sql.Should().Be("([Merchant].[IsEnabled] = 1)");
+        }
+
+        [Fact(DisplayName = "SingleExpression - boolean - false - unary")]
+        public void BooleanExpressionFalseUnary()
+        {
+            Expression<Func<Merchant, bool>> expression = x => !x.IsEnabled;
+            var where = expression.ToSql();
+            where.Sql.Should().Be("([Merchant].[IsEnabled] = 0)");
+        }
     }
 }

--- a/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
+++ b/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
@@ -92,5 +92,21 @@ namespace ExpressionExtensionSQL.Test
             var where = expression.ToSql();
             where.Sql.Should().Be("([tblTeste].[valor] = 1)");
         }
+
+        [Fact(DisplayName = "SingleExpression - IS NULL")]
+        public void IsNullExpression()
+        {
+            Expression<Func<Merchant, bool>> expression = x => x.DeletedAt == null;
+            var where = expression.ToSql();
+            where.Sql.Should().Be("([Merchant].[DeletedAt] IS NULL)");
+        }
+
+        [Fact(DisplayName = "SingleExpression - IS NOT NULL")]
+        public void IsNotNullExpression()
+        {
+            Expression<Func<Merchant, bool>> expression = x => x.DeletedAt != null;
+            var where = expression.ToSql();
+            where.Sql.Should().Be("([Merchant].[DeletedAt] IS NOT NULL)");
+        }
     }
 }

--- a/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
+++ b/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
@@ -138,7 +138,7 @@ namespace ExpressionExtensionSQL.Test
         {
             Expression<Func<Merchant, bool>> expression = x => !x.IsEnabled;
             var where = expression.ToSql();
-            where.Sql.Should().Be("([Merchant].[IsEnabled] = 0)");
+            where.Sql.Should().Be("(NOT ([Merchant].[IsEnabled] = 1))");
         }
     }
 }

--- a/ExpressionExtensionSQL/WhereBuilder.cs
+++ b/ExpressionExtensionSQL/WhereBuilder.cs
@@ -77,7 +77,7 @@ namespace ExpressionExtensionSQL {
             var member = (MemberExpression)expression;
 
             if (isUnary && member.Type == typeof(bool)) {
-                return WherePart.Concat(Recurse(ref i, expression), "=", WherePart.IsParameter(i++, true));
+                return WherePart.Concat(Recurse(ref i, expression), "=", WherePart.IsSql("1"));
             }
 
             if (member.Member is PropertyInfo && left) {
@@ -138,11 +138,8 @@ namespace ExpressionExtensionSQL {
             if (value is string) {
                 value = prefix + (string)value + postfix;
             }
-            if (value is bool) {
-                var boolString = ((bool)value) == true ? "1" : "0";
-                return isUnary ?
-                    WherePart.Concat(WherePart.IsParameter(i++, value), "=", WherePart.IsSql(boolString)) :
-                    WherePart.IsSql(boolString);
+            if (value is bool && !isUnary) {
+                return WherePart.IsSql(((bool)value) ? "1" : "0");
             }
             return WherePart.IsParameter(i++, value);
         }

--- a/ExpressionExtensionSQL/WhereBuilder.cs
+++ b/ExpressionExtensionSQL/WhereBuilder.cs
@@ -138,8 +138,11 @@ namespace ExpressionExtensionSQL {
             if (value is string) {
                 value = prefix + (string)value + postfix;
             }
-            if (value is bool && isUnary) {
-                return WherePart.Concat(WherePart.IsParameter(i++, value), "=", WherePart.IsSql("1"));
+            if (value is bool) {
+                var boolString = ((bool)value) == true ? "1" : "0";
+                return isUnary ?
+                    WherePart.Concat(WherePart.IsParameter(i++, value), "=", WherePart.IsSql(boolString)) :
+                    WherePart.IsSql(boolString);
             }
             return WherePart.IsParameter(i++, value);
         }

--- a/ExpressionExtensionSQL/WhereBuilder.cs
+++ b/ExpressionExtensionSQL/WhereBuilder.cs
@@ -128,6 +128,10 @@ namespace ExpressionExtensionSQL {
         private static WherePart ConstantExpressionExtract(ref int i, Expression expression, bool isUnary, string prefix, string postfix) {
             var constant = (ConstantExpression)expression;
             var value = constant.Value;
+
+            if (value is null) {
+                return WherePart.IsSql("NULL");
+            }
             if (value is int) {
                 return WherePart.IsSql(value.ToString());
             }

--- a/ExpressionExtensionSQL/WherePart.cs
+++ b/ExpressionExtensionSQL/WherePart.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -51,6 +52,10 @@ namespace ExpressionExtensionSQL {
         }
 
         public static WherePart Concat(WherePart left, string @operator, WherePart right) {
+            if (right.Sql.Equals("NULL", StringComparison.InvariantCultureIgnoreCase)) {
+                @operator = @operator == "=" ? "IS" : "IS NOT";
+            }
+
             return new WherePart() {
                 Parameters = left.Parameters.Union(right.Parameters).ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
                 Sql = $"({left.Sql} {@operator} {right.Sql})"


### PR DESCRIPTION
# What have been done?
Expressions that contain null comparisons are transcribed as "IS NULL" or "IS NOT NULL", and expressions with boolean fields, when its not unary, also was transcripted wrong.

# Why it have been done?
The final query couldn't be executed, cause the where clause was getting wrong, like:
```
[Merchant].[DeletedAt] = @1
[Merchant].[IsEnabled] = @1
```
And now, with the fix, it is like:
```
[Merchant].[DeletedAt] IS NULL
[Merchant].[IsEnabled] = 1
```