### PR TITLE
Add typed single return Query method to DapperExtension class

### DIFF
--- a/ExpressionExtensionSQL.Dapper/DapperExtension.cs
+++ b/ExpressionExtensionSQL.Dapper/DapperExtension.cs
@@ -49,6 +49,31 @@ namespace ExpressionExtensionSQL.Dapper {
         /// Perform a multi-mapping query with 2 input types. 
         /// This returns a single type, combined from the raw types via <paramref name="map"/>.
         /// </summary>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for the query.</param>
+        /// <param name="expression">The parameters to pass, if any.</param>
+        /// <param name="transaction">The transaction to use, if any.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
+        /// <param name="commandType">The type of command to execute.</param>
+        /// <returns></returns>
+        public static IEnumerable<TReturn> Query<TReturn>(this IDbConnection cnn,
+            string sql,
+            Expression<Func<TReturn, bool>> expression,
+            IDbTransaction transaction = null,
+            bool buffered = true,
+            int? commandTimeout = null, CommandType? commandType = null)
+        {
+
+            var whereSql = GetWhere(expression, sql);
+            return cnn.Query<TReturn>(whereSql.Key, whereSql.Value, transaction, buffered, commandTimeout, commandType);
+        }
+
+        /// <summary>
+        /// Perform a multi-mapping query with 2 input types. 
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
         /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>

--- a/ExpressionExtensionSQL.Dapper/DapperExtension.cs
+++ b/ExpressionExtensionSQL.Dapper/DapperExtension.cs
@@ -46,7 +46,7 @@ namespace ExpressionExtensionSQL.Dapper {
         }
 
         /// <summary>
-        /// Perform a multi-mapping query with 2 input types. 
+        /// Perform an object of defined <typeparamref name="TReturn"/> type. 
         /// This returns a single type, combined from the raw types via <paramref name="map"/>.
         /// </summary>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>

--- a/ExpressionExtensionSQL.Tests/Entities/Merchant.cs
+++ b/ExpressionExtensionSQL.Tests/Entities/Merchant.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
 namespace ExpressionExtensionSQL.Tests.Entities {
-    public class Merchant {
-
+    public abstract class Entity {
         public int Id { get; set; }
+    }
+    public class Merchant : Entity {
+        
         public string Name { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? DeletedAt { get; set; }

--- a/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
+++ b/ExpressionExtensionSQL.Tests/SingleExpressionTest.cs
@@ -140,5 +140,18 @@ namespace ExpressionExtensionSQL.Test
             var where = expression.ToSql();
             where.Sql.Should().Be("(NOT ([Merchant].[IsEnabled] = 1))");
         }
+
+        [Fact(DisplayName = "SingleExpression - generic filter")]
+        public void GenericFilter()
+        {
+            Expression<Func<Merchant, bool>> expression = x => !x.IsEnabled;
+            var where = Generic(expression);
+            where.Sql.Should().Be("(NOT ([Merchant].[IsEnabled] = 1))");
+        }
+
+        private WherePart Generic<TEntity>(Expression<Func<TEntity, bool>> expression) where TEntity : Entity
+        {
+            return expression.ToSql();
+        }
     }
 }


### PR DESCRIPTION
# What have been done?
A new Query method has been included, which the expression is of a defined type.

# Why it have been done?
When the expression is of a inherited type, the transcription of ***where clause*** is affected by the conversion to **Expression<Func<dynamic, bool>>** type