### PR TITLE
Fix bool false to become 0=1 when not unary

### DIFF
--- a/ExpressionExtensionSQL.Tests/ConcatinatedExpressionTests.cs
+++ b/ExpressionExtensionSQL.Tests/ConcatinatedExpressionTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq.Expressions;
+using ExpressionExtensionSQL.Extensions;
+using ExpressionExtensionSQL.Tests.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace ExpressionExtensionSQL.Tests
+{
+    public class ConcatenatedExpressionTest
+    {
+        [Fact(DisplayName = "ConcatenatedExpression - false OR Equal")]
+        public void FalseOrEqualExpression()
+        {
+            Expression<Func<Merchant, bool>> expression = x => false || x.Name == "merchant1";
+            var where = expression.ToSql();
+            where.Sql.Should().Be("(0=1 OR ([Merchant].[Name] = @1))");
+        }
+
+        [Fact(DisplayName = "ConcatenatedExpression - true OR Equal")]
+        public void TrueOrEqualExpression()
+        {
+            Expression<Func<Merchant, bool>> expression = x => true || x.Name == "merchant1";
+            var where = expression.ToSql();
+            where.Sql.Should().Be("(1=1 OR ([Merchant].[Name] = @1))");
+        }
+
+        [Fact(DisplayName = "ConcatenatedExpression - false AND Equal")]
+        public void FalseAndEqualExpression()
+        {
+            Expression<Func<Merchant, bool>> expression = x => false && x.Name == "merchant1";
+            var where = expression.ToSql();
+            where.Sql.Should().Be("(0=1 AND ([Merchant].[Name] = @1))");
+        }
+
+        [Fact(DisplayName = "ConcatenatedExpression - true AND Equal")]
+        public void TrueAndEqualExpression()
+        {
+            Expression<Func<Merchant, bool>> expression = x => true && x.Name == "merchant1";
+            var where = expression.ToSql();
+            where.Sql.Should().Be("(1=1 AND ([Merchant].[Name] = @1))");
+        }
+    }
+}

--- a/ExpressionExtensionSQL.Tests/ExpressionExtensionSQL.Tests.csproj
+++ b/ExpressionExtensionSQL.Tests/ExpressionExtensionSQL.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/ExpressionExtensionSQL/WhereBuilder.cs
+++ b/ExpressionExtensionSQL/WhereBuilder.cs
@@ -208,11 +208,14 @@ namespace ExpressionExtensionSQL
                     break;
             }
 
-            if (!(value is bool) || isUnary) return WherePart.IsParameter(i++, value);
+            if (!(value is bool boolValue) || isUnary) return WherePart.IsParameter(i++, value);
 
-            var result = ((bool) value) ? "1" : "0";
+            string result;
             if (left)
-                result = result.Equals("1") ? "1=1" : "0=0";
+                result = boolValue ? "1=1" : "0=1";
+            else
+                result = boolValue ? "1" : "0";
+
             return WherePart.IsSql(result);
         }
 


### PR DESCRIPTION
0=0 is true. For false it should be 0=1 instead.

Adds a few tests for concatenated expressions to cover this.